### PR TITLE
fix: Handle that original schema can resolve to null

### DIFF
--- a/src/main/java/io/openapitools/hal/HALModelConverter.java
+++ b/src/main/java/io/openapitools/hal/HALModelConverter.java
@@ -40,6 +40,9 @@ public class HALModelConverter extends AbstractModelConverter {
         }
 
         Schema<?> originalSchema = chain.next().resolve(annotatedType, context, chain);
+        if (originalSchema == null) {
+            return null;
+        }
         Schema<?> schema = originalSchema;
 
         if (originalSchema.get$ref() != null) {

--- a/src/test/java/io/openapitools/hal/HALModelConverterTest.java
+++ b/src/test/java/io/openapitools/hal/HALModelConverterTest.java
@@ -1,0 +1,28 @@
+package io.openapitools.hal;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.Collections;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+
+class HALModelConverterTest {
+
+  final HALModelConverter halModelConverter = new HALModelConverter();
+
+  @Test
+  void shouldNotFailIfOriginalSchemaResolvesToNull() {
+    AnnotatedType annotatedType = mock(AnnotatedType.class);
+    ModelConverterContext modelConverterContext = mock(ModelConverterContext.class);
+    ModelConverter mockModelConverter = mock(ModelConverter.class);
+
+    Iterator<ModelConverter> converterChain = Collections.singleton(mockModelConverter).iterator();
+    Schema result = halModelConverter.resolve(annotatedType, modelConverterContext, converterChain);
+    assertNull(result);
+  }
+}


### PR DESCRIPTION
We have some rare cases when we get a NPE from your HALModelConverter:

```
java.lang.NullPointerException: null
	at io.openapitools.hal.HALModelConverter.resolve(HALModelConverter.java:45)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:656)
	at io.openapitools.hal.HALModelConverter.resolve(HALModelConverter.java:42)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:656)
	at io.openapitools.hal.HALModelConverter.resolve(HALModelConverter.java:42)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at io.swagger.v3.core.converter.ModelConverters.resolveAsResolvedSchema(ModelConverters.java:117)
	at io.swagger.v3.core.util.ParameterProcessor.applyAnnotations(ParameterProcessor.java:63)
	at io.swagger.v3.jaxrs2.DefaultParameterExtension.extractParameters(DefaultParameterExtension.java:117)
	at io.swagger.v3.jaxrs2.Reader.getParameters(Reader.java:1339)
	at io.swagger.v3.jaxrs2.Reader.read(Reader.java:543)
	at io.swagger.v3.jaxrs2.Reader.read(Reader.java:183)
	at io.swagger.v3.jaxrs2.Reader.read(Reader.java:211)
```

I did not add an integration test that contains the specific models but added a simple unit test. I think this case should be handled since the documentation of the `ModelConverter` interface states:
> @return null if this ModelConverter cannot convert the given Type

In case you're curious where we use your library you can take a look at our open source library for setting up microservices: https://github.com/SDA-SE/sda-dropwizard-commons

Thanks!